### PR TITLE
Fix conversation length trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ async function generateResponse(userId, prompt) {
     const response = completion.choices[0].message.content.trim();
 
     conversation.push({ role: 'assistant', content: response });
+
+    if (conversation.length > 10) {
+      conversation = conversation.slice(conversation.length - 10);
+    }
+
     userConversations.set(userId, conversation);
 
     return response;


### PR DESCRIPTION
## Summary
- ensure chat history is trimmed after adding assistant replies

## Testing
- `npm test` *(fails: Missing script)*
- `DISCORD_BOT_TOKEN=invalid OPENAI_API_KEY=invalid node index.js` *(fails: cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6848cde6e3e0832e9a92accb3c215533