### PR TITLE
Add mention regex tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "discord.js": "^14.13.0",

--- a/test/mentionRegex.test.js
+++ b/test/mentionRegex.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const regex = /<@!?(\d+)>/;
+
+const cases = [
+  ['<@123456> hello', 'hello'],
+  ['<@!123456> hello', 'hello'],
+];
+
+for (const [input, expected] of cases) {
+  test(`extract prompt from "${input}"`, () => {
+    const result = input.replace(regex, '').trim();
+    assert.equal(result, expected);
+  });
+}


### PR DESCRIPTION
## Summary
- add basic test verifying mention regex behavior
- allow `npm test` to run Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ced1d320832e817e9326f675e7e5